### PR TITLE
Add collateral ratio to find_tdts.js

### DIFF
--- a/find_tdts.js
+++ b/find_tdts.js
@@ -24,7 +24,7 @@ async function main() {
 		const tbtcSysContract = new ethers.Contract(TBTCSystem.networks["1"].address, TBTCSystem.abi, ip);
 		const tdtContract = new ethers.Contract(TBTCDepositToken.networks["1"].address, TBTCDepositToken.abi, ip);
 		const depositLogContract = new ethers.Contract(TBTCSystem.networks["1"].address, DepositLog.abi, ip);
-		
+
 		const keeps = await ecdsaKFContract.queryFilter(ecdsaKFContract.filters.BondedECDSAKeepCreated());
 		const targetKeeps = keeps.filter(ev => { return ev.args[1].filter(ms => { return ms.toLowerCase() === opAddr}).length > 0 }).map(ev => { return ev.args[0]; });
 
@@ -33,11 +33,12 @@ async function main() {
 			const tdt = await depositLogContract.queryFilter(depositLogContract.filters.Created(null, addr));
 			if (tdt.length < 1) { continue; }
 			const d = new ethers.Contract(tdt[0].args[0], Deposit.abi, ip);
+			const r = await d.collateralizationPercentage()
 			const depositState = states[await d.currentState()];
 			//const keepActive = (await k.isActive()) ? "active" : "inactive";
 			//const depositActive = (await d.inActive()) ? "active" : "inactive";
 
-			console.log(`keep ${addr} manages TDT ${d.address} (${ethers.utils.formatEther(await d.lotSizeTbtc())} tBTC) with state: ${depositState}`);
+			console.log(`keep ${addr} manages TDT ${d.address} (${ethers.utils.formatEther(await d.lotSizeTbtc())} tBTC) | has ratio ${r} with state: ${depositState}`);
 		}
 
 	} catch(err) {
@@ -49,4 +50,3 @@ async function main() {
 main().catch(err => {
 	console.error(err);
 })
-


### PR DESCRIPTION
It's nice to have the collateral ratio shown for each TDT our nodes have, this helps us get a quick overview of the status of our node. 